### PR TITLE
Mate merge this now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # shiori
 
-Note is using Powershell you may need to set it to use UTF-8 explicity so it prints out the unicode characters
+Example Usage to send to a MongoDB backend:
+```bash
+python ./shiori/shiori.py --load-covers --export-opts "mongo_uri=mongodb://<username>:<password>@qwerwrt-shard-00-00-b5hdc.mongodb.net:27017/test?ssl=true&replicaSet=qwetewq-shard-0&authSource=admin,mongo_db=wqerweq,mongo_collection=werweq" ./Songs mongo
+```
+
+Note if using Powershell you may need to set it to use UTF-8 explicity so it prints out the unicode characters
 correctly in the console. The following command does this
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # shiori
+
+Note is using Powershell you may need to set it to use UTF-8 explicity so it prints out the unicode characters
+correctly in the console. The following command does this
+
+```powershell
+$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding =
+                    New-Object System.Text.UTF8Encoding
+```
+
+To persist these settings, i.e. to make your future interactive PowerShell sessions UTF-8-aware by default, add the command above to your `$PROFILE ` file.
+
+Any errors found during the scraping process is outputted to a log file.

--- a/export_formats/mongo.py
+++ b/export_formats/mongo.py
@@ -7,9 +7,11 @@ def export(args, opts, library):
         logging.error("Please include `--export-opts \"mongo_uri=mongodb://<addr>:<port>,mongo_db=<db_name>,mongo_collection=<collection_name>\"`")
         return
     else:
+        print("Mongo uri = %s" % opts["mongo_uri"])
         client = pymongo.MongoClient(opts["mongo_uri"])
         collection = client[opts["mongo_db"]][opts["mongo_collection"]]
         for song in library.library:
+            logging.info("Attempting to export song: %s - %s" % (song.title, song.artist))
             export_song(args, collection, opts, song)
 
 def export_song(args, c, opts, song):
@@ -50,14 +52,14 @@ def create_song_dict(args, song):
         try:
             d["cover"] = song.load_cover()
         except AttributeError:
-            logging.info("Song " + song.title + " is does not have cover included.")
+            logging.warning("Song " + song.title + " is does not have cover included.")
         except Exception as e:
             logging.warning("failed to load cover for " + song.title + " with error " + str(e))
     if args.bgs:
         try:
             d["bg"] = song.load_bg()
         except AttributeError:
-            logging.info("Song " + song.title + " is does not have background included.")
+            logging.warning("Song " + song.title + " is does not have background included.")
         except Exception as e:
             logging.warning("failed to load background for " + song.title + " with error " + str(e))
     return d

--- a/ultraparse.py
+++ b/ultraparse.py
@@ -33,7 +33,13 @@ class SongFile:
 
     def parse_line(self, line):
         if line[0] == "#":
-            [com, val] = line.split(':', 1)
+            try:
+                [com, val] = line.split(':', 1)
+            except ValueError:
+                # Badly formatted line. We shall skip
+                line = self.next_line()
+                self.parse_line(line)
+                return
             com = str.strip(com[1:]).upper()
             val = str.strip(val)
             #Metadata tag


### PR DESCRIPTION

Shiori has much better logging now. Info logs are still printed
to stdout (and therefore console) which means users can see
easily the progress of the script. Logging warning level and
above are redirected out to a log file allowing the user to quickly
see which files have not been successfully parsed. Also:
- Fixed an issue in ultraparse.py where it would automatically
  assume a line beginning with a # is correctly formatted with
  a colon. This could lead to unpack errors so a try-except block
  has been added to catch this
- Removed an for loop in the parse_songfile function which I
  assume is only to check that the whole file can be decoded
  correctly. However some files only had garbage data at the
  end, and thus the metadata could still be parsed correctly.